### PR TITLE
feat: contact warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ resolution = np.array([32,32,40])
 
 # cross sectional area returned as a float
 area = xs3d.cross_sectional_area(binary_image, vertex, normal, resolution)
+
+# optionally return a boolean that tells you if the section
+# plane touched the image border, indicating a possible
+# underestimate of the area if the image is a cutout of
+# a larger scene.
+area, contact_warning = xs3d.cross_sectional_area(
+	binary_image, vertex, normal, resolution, 
+	return_contact=True
+)
+
 ```
 
 When using skeletons (one dimensional stick figure representations) to create electrophysiological compartment simulations of neurons, some additional information is required for accuracy. The caliber of the neurite changes over the length of the cell.

--- a/src/fastxs3d.cpp
+++ b/src/fastxs3d.cpp
@@ -10,7 +10,7 @@
 
 namespace py = pybind11;
 
-float xsa(
+auto xsa(
 	const py::array_t<uint8_t> &binimg,
 	const py::array_t<float> &point,
 	const py::array_t<float> &normal,
@@ -24,13 +24,16 @@ float xsa(
 		? 1 
 		: binimg.shape()[2];
 
-	return xs3d::cross_sectional_area(
+	bool contact = false;
+	float area = xs3d::cross_sectional_area(
 		binimg.data(),
 		sx, sy, sz,
 		point.at(0), point.at(1), point.at(2),
 		normal.at(0), normal.at(1), normal.at(2),
-		anisotropy.at(0), anisotropy.at(1), anisotropy.at(2)
+		anisotropy.at(0), anisotropy.at(1), anisotropy.at(2),
+		contact
 	);
+	return std::tuple(area, contact);
 }
 
 PYBIND11_MODULE(fastxs3d, m) {

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -398,7 +398,8 @@ float cross_sectional_area_helper(
 	const uint64_t sx, const uint64_t sy, const uint64_t sz,
 	const Vec3& pos, // plane position
 	const Vec3& normal, // plane normal vector
-	const Vec3& anisotropy // anisotropy
+	const Vec3& anisotropy, // anisotropy
+	bool& contact
 ) {
 	std::vector<bool> ccl(sx * sy * sz);
 
@@ -449,6 +450,13 @@ float cross_sectional_area_helper(
 		float dy = static_cast<float>(y) - static_cast<float>(plane_pos_y);
 
 		Vec3 cur = pos + basis1 * dx + basis2 * dy;
+
+		if (cur.x < 1 || cur.y < 1 || cur.z < 1) {
+			contact = true;
+		}
+		else if (cur.x >= sx - 1 || cur.y >= sy - 1 || cur.z >= sz - 1) {
+			contact = true;
+		}
 
 		if (cur.x < 0 || cur.y < 0 || cur.z < 0) {
 			continue;
@@ -512,6 +520,8 @@ float cross_sectional_area_helper(
 	return total;
 }
 
+static bool _dummy_contact = false;
+
 };
 
 namespace xs3d {
@@ -522,7 +532,8 @@ float cross_sectional_area(
 	
 	const float px, const float py, const float pz,
 	const float nx, const float ny, const float nz,
-	const float wx, const float wy, const float wz
+	const float wx, const float wy, const float wz,
+	bool &contact = _dummy_contact 
 ) {
 
 	if (px < 0 || px >= sx) {
@@ -551,7 +562,8 @@ float cross_sectional_area(
 	return cross_sectional_area_helper(
 		binimg, 
 		sx, sy, sz, 
-		pos, normal, anisotropy
+		pos, normal, anisotropy,
+		contact
 	);
 }
 

--- a/xs3d/__init__.py
+++ b/xs3d/__init__.py
@@ -10,6 +10,7 @@ def cross_sectional_area(
   pos:Sequence[int],
   normal:Sequence[float],
   anisotropy:Optional[Sequence[float]] = None,
+  return_contact:bool = False,
 ):
   if anisotropy is None:
     anisotropy = [ 1.0 ] * binimg.ndim
@@ -30,7 +31,15 @@ def cross_sectional_area(
   binimg = np.asfortranarray(binimg)
 
   if binimg.ndim == 2:
-    return cross_sectional_area_2d(binimg, pos, normal, anisotropy)
+    contact = False
+    area = cross_sectional_area_2d(binimg, pos, normal, anisotropy)
   elif binimg.ndim == 3:
-    return fastxs3d.xsa(binimg, pos, normal, anisotropy)
-  raise ValueError("dimensions not supported")
+    area, contact = fastxs3d.xsa(binimg, pos, normal, anisotropy)
+  else:
+    raise ValueError("dimensions not supported")
+
+  if return_contact:
+    return (area, contact)
+  else:
+    return area
+

--- a/xs3d/__init__.py
+++ b/xs3d/__init__.py
@@ -53,8 +53,7 @@ def cross_sectional_area(
   binimg = np.asfortranarray(binimg)
 
   if binimg.ndim == 2:
-    contact = False
-    area = cross_sectional_area_2d(binimg, pos, normal, anisotropy)
+    area, contact = cross_sectional_area_2d(binimg, pos, normal, anisotropy)
   elif binimg.ndim == 3:
     area, contact = fastxs3d.xsa(binimg, pos, normal, anisotropy)
   else:

--- a/xs3d/__init__.py
+++ b/xs3d/__init__.py
@@ -11,7 +11,29 @@ def cross_sectional_area(
   normal:Sequence[float],
   anisotropy:Optional[Sequence[float]] = None,
   return_contact:bool = False,
-):
+) -> float:
+  """
+  Find the cross sectional area for a given binary image, 
+  point, and normal vector.
+
+  binimg: a binary 2d or 3d numpy image (e.g. a bool datatype)
+  pos: the point in the image from which to extract the section
+    must be an integer (it's an index into the image).
+    e.g. [5,10,2]
+  normal: a vector normal to the section plane, does not
+    need to be a unit vector. e.g. [sqrt(2)/2. sqrt(2)/2, 0]
+  anisotropy: resolution of the x, y, and z axis
+    e.g. [4,4,40] for an electron microscope image with 
+    4nm XY resolution with a 40nm cutting plane in 
+    serial sectioning.
+  return_contact: if true, return a tuple of (area, contact)
+    where area is the usual output and contact is True if
+    the section plane has contacted the edge of the image
+    indicating the area may be an underestimate if you are
+    working with a cutout of a larger image.
+
+  Returns: physical area covered by the section plane
+  """
   if anisotropy is None:
     anisotropy = [ 1.0 ] * binimg.ndim
 

--- a/xs3d/twod.py
+++ b/xs3d/twod.py
@@ -102,10 +102,17 @@ def cross_sectional_area_2d(
   wx, wy = float(anisotropy[0]), float(anisotropy[1])
 
   y_intercept = pos[1] - slope * pos[0]
+  contact = False
+
   for y in range(sy):
     for x in range(sx):
       if ccl[x,y] != label:
         continue
+
+      if x in (0, sx-1):
+        contact = True
+      elif y in (0, sy-1):
+        contact = True
 
       h0 = float(y) - 0.5
       h1 = float(y) + 0.5
@@ -152,18 +159,6 @@ def cross_sectional_area_2d(
 
       total += np.sqrt(px*px + py*py)
 
-  return total
-
-
-
-
-
-
-
-
-
-
-
-
+  return total, contact
 
 


### PR DESCRIPTION
optionally return a boolean `contact` that means the section plane touched the image border, indicating a possible underestimate of the area.