### PR TITLE
feat: slice operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ area, contact_warning = xs3d.cross_sectional_area(
 	return_contact=True
 )
 
-# Returns the cross section as a float32 image
+# Returns the cross section as a float32 3d image
 # where each voxel represents its contribution
 # to the cross sectional area
 image = xs3d.cross_section(
@@ -47,7 +47,10 @@ image = xs3d.cross_section(
 	normal, resolution, 
 )
 
-
+# Get a slice of a 3d image in any orientation.
+# Note: result may be reflected or transposed
+# compared with what you might expect.
+image2d = xs3d.slice(labels, vertex, normal)
 ```
 
 When using skeletons (one dimensional stick figure representations) to create electrophysiological compartment simulations of neurons, some additional information is required for accuracy. The caliber of the neurite changes over the length of the cell.

--- a/automated_test.py
+++ b/automated_test.py
@@ -304,7 +304,10 @@ def test_cross_section():
 		assert image.dtype == np.float32
 		assert np.isclose(image.sum(), area)
 
-
+def test_slice():
+	labels = np.arange(9, dtype=np.uint8).reshape([3,3,1], order="F")
+	slc = xs3d.slice(labels, [0,0,0], [0,0,1])
+	assert np.all(slc == labels[:,:,0])
 
 
 

--- a/src/fastxs3d.cpp
+++ b/src/fastxs3d.cpp
@@ -81,7 +81,7 @@ auto projection(
 		? 1 
 		: labels.shape()[2];
 
-	uint64_t psx = 2 * std::max(std::max(sx,sy), sz);
+	uint64_t psx = 2 * sqrt(3) * std::max(std::max(sx,sy), sz);
 	uint64_t pvoxels = psx * psx;
 
 	py::array arr; 

--- a/src/fastxs3d.cpp
+++ b/src/fastxs3d.cpp
@@ -81,7 +81,7 @@ auto projection(
 		? 1 
 		: labels.shape()[2];
 
-	uint64_t psx = 2 * sqrt(3) * std::max(std::max(sx,sy), sz);
+	uint64_t psx = 2 * sqrt(3) * std::max(std::max(sx,sy), sz) + 1;
 	uint64_t pvoxels = psx * psx;
 
 	py::array arr; 

--- a/src/fastxs3d.cpp
+++ b/src/fastxs3d.cpp
@@ -88,8 +88,8 @@ auto projection(
 
 	auto projectionfn = [&](auto dtype) {
 		arr = py::array_t<decltype(dtype), py::array::f_style>(pvoxels);
-		auto out = static_cast<decltype(dtype)*>(arr.request().ptr);
-		auto data = static_cast<decltype(dtype)*>(labels.request().ptr);
+		auto out = reinterpret_cast<decltype(dtype)*>(arr.request().ptr);
+		auto data = reinterpret_cast<decltype(dtype)*>(labels.request().ptr);
 		std::fill(out, out + pvoxels, 0);
 
 		xs3d::cross_section_projection<decltype(dtype)>(

--- a/src/fastxs3d.cpp
+++ b/src/fastxs3d.cpp
@@ -81,7 +81,9 @@ auto projection(
 		? 1 
 		: labels.shape()[2];
 
-	uint64_t psx = 2 * sqrt(3) * std::max(std::max(sx,sy), sz) + 1;
+	// rational approximation of sqrt(3) is 97/56
+	// result is more likely to be same across compilers
+	uint64_t psx = 2 * 97 * std::max(std::max(sx,sy), sz) / 56 + 1;
 	uint64_t pvoxels = psx * psx;
 
 	py::array arr; 

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -423,9 +423,9 @@ float cross_sectional_area_helper(
 ) {
 	std::vector<bool> ccl(sx * sy * sz);
 
-	// rational approximation of sqrt(3) is 71/41
+	// rational approximation of sqrt(3) is 97/56
 	// more reliable behavior across compilers/architectures
-	uint64_t plane_size = 2 * 71 * std::max(std::max(sx,sy), sz) / 41 + 1;
+	uint64_t plane_size = 2 * 97 * std::max(std::max(sx,sy), sz) / 56 + 1;
 
 	// maximum possible size of plane
 	uint64_t psx = plane_size;
@@ -666,8 +666,8 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 	LABEL* out = NULL
 ) {
 	// maximum possible size of plane
-	// rational approximation of sqrt(3) is 71/41
-	const uint64_t psx = 2 * 71 * std::max(std::max(sx,sy), sz) / 41 + 1;
+	// rational approximation of sqrt(3) is 97/56
+	const uint64_t psx = 2 * 97 * std::max(std::max(sx,sy), sz) / 56 + 1;
 	const uint64_t psy = psx;
 
 	Bbox2d bbx;

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -724,11 +724,6 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 		uint64_t y = ploc / psx;
 		uint64_t x = ploc - y * psx;
 
-		bbx.x_min = std::min(bbx.x_min, static_cast<int64_t>(x));
-		bbx.x_max = std::max(bbx.x_max, static_cast<int64_t>(x));
-		bbx.y_min = std::min(bbx.y_min, static_cast<int64_t>(y));
-		bbx.y_max = std::max(bbx.y_max, static_cast<int64_t>(y));
-
 		float dx = static_cast<float>(x) - static_cast<float>(plane_pos_x);
 		float dy = static_cast<float>(y) - static_cast<float>(plane_pos_y);
 
@@ -740,6 +735,11 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 		else if (cur.x >= sx || cur.y >= sy || cur.z >= sz) {
 			continue;
 		}
+
+		bbx.x_min = std::min(bbx.x_min, static_cast<int64_t>(x));
+		bbx.x_max = std::max(bbx.x_max, static_cast<int64_t>(x));
+		bbx.y_min = std::min(bbx.y_min, static_cast<int64_t>(y));
+		bbx.y_max = std::max(bbx.y_max, static_cast<int64_t>(y));
 
 		uint64_t loc = static_cast<uint64_t>(cur.x) + sx * (
 			static_cast<uint64_t>(cur.y) + sy * static_cast<uint64_t>(cur.z)

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -689,13 +689,13 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 	Vec3 normal(nx, ny, nz);
 	normal /= normal.norm();
 
-	Vec3 basis1 = normal.cross(ihat);
+	Vec3 basis1 = jhat.cross(normal);
 	if (basis1.is_null()) {
-		basis1 = normal.cross(jhat);
+		basis1 = normal.cross(ihat);
 	}
 	basis1 /= basis1.norm();
 
-	Vec3 basis2 = basis1.cross(normal);
+	Vec3 basis2 = normal.cross(basis1);
 	basis2 /= basis2.norm();
 
 	uint64_t plane_pos_x = psx / 2;

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -643,7 +643,7 @@ LABEL* cross_section_projection(
 	LABEL* out = NULL
 ) {
 	// maximum possible size of plane
-	const uint64_t psx = 2 * std::max(std::max(sx,sy), sz);
+	const uint64_t psx = 2 * sqrt(3) * std::max(std::max(sx,sy), sz);
 	const uint64_t psy = psx;
 
 	std::unique_ptr<bool[]> visited(new bool[psx * psy]());

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -695,7 +695,7 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 	}
 	basis1 /= basis1.norm();
 
-	Vec3 basis2 = normal.cross(basis1);
+	Vec3 basis2 = basis1.cross(normal);
 	basis2 /= basis2.norm();
 
 	uint64_t plane_pos_x = psx / 2;

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -643,10 +643,10 @@ LABEL* cross_section_projection(
 	LABEL* out = NULL
 ) {
 	// maximum possible size of plane
-	const uint64_t psx = 2 * sqrt(3) * std::max(std::max(sx,sy), sz);
+	const uint64_t psx = 2 * sqrt(3) * std::max(std::max(sx,sy), sz) + 1;
 	const uint64_t psy = psx;
 
-	std::unique_ptr<bool[]> visited(new bool[psx * psy]());
+	std::vector<bool> visited(psx * psy);
 
 	if (out == NULL) {
 		out = new LABEL[psx * psy]();

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -423,7 +423,9 @@ float cross_sectional_area_helper(
 ) {
 	std::vector<bool> ccl(sx * sy * sz);
 
-	uint64_t plane_size = 2 * sqrt(3) * std::max(std::max(sx,sy), sz) + 1;
+	// rational approximation of sqrt(3) is 71/41
+	// more reliable behavior across compilers/architectures
+	uint64_t plane_size = 2 * 71 * std::max(std::max(sx,sy), sz) / 41 + 1;
 
 	// maximum possible size of plane
 	uint64_t psx = plane_size;
@@ -664,7 +666,8 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 	LABEL* out = NULL
 ) {
 	// maximum possible size of plane
-	const uint64_t psx = 2 * sqrt(3) * std::max(std::max(sx,sy), sz) + 1;
+	// rational approximation of sqrt(3) is 71/41
+	const uint64_t psx = 2 * 71 * std::max(std::max(sx,sy), sz) / 41 + 1;
 	const uint64_t psy = psx;
 
 	Bbox2d bbx;

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -561,7 +561,7 @@ struct Bbox2d {
 		return sx() * sy();
 	}
 	void print() const {
-		printf("Bbox2d(%d, %d, %d, %d)\n", x_min, x_max, y_min, y_max);
+		printf("Bbox2d(%llu, %llu, %llu, %llu)\n", x_min, x_max, y_min, y_max);
 	}
 };
 

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -755,25 +755,6 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 		uint64_t left = ploc - 1;
 		uint64_t right = ploc + 1;
 
-		uint64_t upleft = ploc - psx - 1; 
-		uint64_t downleft = ploc + psx - 1;
-		uint64_t upright = ploc - psx + 1;
-		uint64_t downright = ploc + psx + 1;
-
-
-		if (x > 0 && y > 0 && !visited[upleft]) {
-			stack.push(upleft);
-		}
-		if (x < psx - 1 && y > 0 && !visited[upright]) {
-			stack.push(upright);
-		}
-		if (x > 0 && y < psy - 1 && !visited[downleft]) {
-			stack.push(downleft);
-		}
-		if (x < psx - 1 && y < psy - 1 && !visited[downright]) {
-			stack.push(downright);
-		}
-
 		if (x > 0 && !visited[left]) {
 			stack.push(left);
 		}

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -757,18 +757,6 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 		uint64_t upright = ploc - psx + 1;
 		uint64_t downright = ploc + psx + 1;
 
-		if (x > 0 && !visited[left]) {
-			stack.push(left);
-		}
-		if (x < psx - 1 && !visited[right]) {
-			stack.push(right);
-		}
-		if (y > 0 && !visited[up]) {
-			stack.push(up);
-		}
-		if (y < psy - 1 && !visited[down]) {
-			stack.push(down);
-		}
 
 		if (x > 0 && y > 0 && !visited[upleft]) {
 			stack.push(upleft);
@@ -781,6 +769,19 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 		}
 		if (x < psx - 1 && y < psy - 1 && !visited[downright]) {
 			stack.push(downright);
+		}
+
+		if (x > 0 && !visited[left]) {
+			stack.push(left);
+		}
+		if (x < psx - 1 && !visited[right]) {
+			stack.push(right);
+		}
+		if (y > 0 && !visited[up]) {
+			stack.push(up);
+		}
+		if (y < psy - 1 && !visited[down]) {
+			stack.push(down);
 		}
 	}
 

--- a/xs3d/__init__.py
+++ b/xs3d/__init__.py
@@ -118,3 +118,35 @@ def cross_section(
   else:
     raise ValueError("dimensions not supported")
 
+def projection(
+  labels:np.ndarray,
+  pos:Sequence[int],
+  normal:Sequence[float],
+) -> np.ndarray:
+  """
+  Compute which voxels are intercepted by a section plane
+  (defined by a normal vector).
+
+  labels: a binary 2d or 3d numpy image (e.g. a bool datatype)
+  pos: the point in the image from which to extract the section
+    must be an integer (it's an index into the image).
+    e.g. [5,10,2]
+  normal: a vector normal to the section plane, does not
+    need to be a unit vector. e.g. [sqrt(2)/2. sqrt(2)/2, 0]
+
+  Returns: ndarray
+  """
+  pos = np.array(pos, dtype=np.float32)
+  normal = np.array(normal, dtype=np.float32)
+
+  if np.all(normal == 0):
+    raise ValueError("normal vector must not be a null vector (all zeros).")
+
+  labels = np.asfortranarray(labels)
+
+  if labels.ndim == 3:
+    return fastxs3d.projection(labels, pos, normal)
+  else:
+    raise ValueError("dimensions not supported")
+
+

--- a/xs3d/__init__.py
+++ b/xs3d/__init__.py
@@ -144,9 +144,16 @@ def projection(
 
   labels = np.asfortranarray(labels)
 
-  if labels.ndim == 3:
-    return fastxs3d.projection(labels, pos, normal)
-  else:
-    raise ValueError("dimensions not supported")
+  if labels.ndim != 3:
+    raise ValueError(f"{labels.ndim} dimensions not supported")
+
+  return fastxs3d.projection(labels, pos, normal)
+
+
+
+
+
+
+    
 
 

--- a/xs3d/__init__.py
+++ b/xs3d/__init__.py
@@ -118,7 +118,7 @@ def cross_section(
   else:
     raise ValueError("dimensions not supported")
 
-def projection(
+def slice(
   labels:np.ndarray,
   pos:Sequence[int],
   normal:Sequence[float],
@@ -126,6 +126,10 @@ def projection(
   """
   Compute which voxels are intercepted by a section plane
   and project them onto a plane.
+
+  NB: The orientation of this projection is not guaranteed. 
+  The axes can be reflected and transposed compared to what
+  you might expect.
 
   labels: a binary 2d or 3d numpy image (e.g. a bool datatype)
   pos: the point in the image from which to extract the section

--- a/xs3d/__init__.py
+++ b/xs3d/__init__.py
@@ -125,7 +125,7 @@ def projection(
 ) -> np.ndarray:
   """
   Compute which voxels are intercepted by a section plane
-  (defined by a normal vector).
+  and project them onto a plane.
 
   labels: a binary 2d or 3d numpy image (e.g. a bool datatype)
   pos: the point in the image from which to extract the section


### PR DESCRIPTION
Adds `xs3d.slice` which enables taking an image slice from any location and orientation in an image. Results are returned as a close-cropped region of interest and may take the form of triangles, rectangles, pentagons, or hexagons.