### PR TITLE
perf(slice): reduce memory allocation + replace stack

### DIFF
--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -809,7 +809,7 @@ Bbox2d compute_slice_plane(
 }
 
 template <typename LABEL>
-std::tuple<LABEL*, uint64_t, Bbox2d> cross_section_projection(
+std::tuple<LABEL*, int64_t, Bbox2d> cross_section_projection(
 	const LABEL* labels,
 	const uint64_t sx, const uint64_t sy, const uint64_t sz,
 	
@@ -832,8 +832,8 @@ std::tuple<LABEL*, uint64_t, Bbox2d> cross_section_projection(
 
 	Bbox2d plane_bbx = compute_slice_plane(pos, basis1, basis2, sx, sy, sz);
 
-	const uint64_t psx = plane_bbx.sx();
-	const uint64_t psy = plane_bbx.sy();
+	const int64_t psx = plane_bbx.sx();
+	const int64_t psy = plane_bbx.sy();
 
 	LABEL* out = new LABEL[psx * psy]();
 

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -816,63 +816,32 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 	bbx.y_min = plane_pos_y;
 	bbx.y_max = plane_pos_y;
 
-	uint64_t ploc = plane_pos_x + psx * plane_pos_y;
+	for (float y = 0; y < psy; y++) {
+		for (float x = 0; x < psx; x++) {
 
-	std::stack<uint64_t> stack;
-	stack.push(ploc);
+			float dx = static_cast<float>(x) - static_cast<float>(plane_pos_x);
+			float dy = static_cast<float>(y) - static_cast<float>(plane_pos_y);
 
-	while (!stack.empty()) {
-		ploc = stack.top();
-		stack.pop();
+			Vec3 cur = pos + basis1 * dx + basis2 * dy;			
 
-		if (visited[ploc]) {
-			continue;
-		}
+			if (cur.x < 0 || cur.y < 0 || cur.z < 0) {
+				continue;
+			}
+			else if (cur.x >= sx || cur.y >= sy || cur.z >= sz) {
+				continue;
+			}
 
-		visited[ploc] = true;
+			bbx.x_min = std::min(bbx.x_min, static_cast<int64_t>(x));
+			bbx.x_max = std::max(bbx.x_max, static_cast<int64_t>(x));
+			bbx.y_min = std::min(bbx.y_min, static_cast<int64_t>(y));
+			bbx.y_max = std::max(bbx.y_max, static_cast<int64_t>(y));
 
-		uint64_t y = ploc / psx;
-		uint64_t x = ploc - y * psx;
-
-		float dx = static_cast<float>(x) - static_cast<float>(plane_pos_x);
-		float dy = static_cast<float>(y) - static_cast<float>(plane_pos_y);
-
-		Vec3 cur = pos + basis1 * dx + basis2 * dy;
-
-		if (cur.x < 0 || cur.y < 0 || cur.z < 0) {
-			continue;
-		}
-		else if (cur.x >= sx || cur.y >= sy || cur.z >= sz) {
-			continue;
-		}
-
-		bbx.x_min = std::min(bbx.x_min, static_cast<int64_t>(x));
-		bbx.x_max = std::max(bbx.x_max, static_cast<int64_t>(x));
-		bbx.y_min = std::min(bbx.y_min, static_cast<int64_t>(y));
-		bbx.y_max = std::max(bbx.y_max, static_cast<int64_t>(y));
-
-		uint64_t loc = static_cast<uint64_t>(cur.x) + sx * (
-			static_cast<uint64_t>(cur.y) + sy * static_cast<uint64_t>(cur.z)
-		);
-
-		out[ploc] = labels[loc];
-
-		uint64_t up = ploc - psx; 
-		uint64_t down = ploc + psx;
-		uint64_t left = ploc - 1;
-		uint64_t right = ploc + 1;
-
-		if (x > 0 && !visited[left]) {
-			stack.push(left);
-		}
-		if (x < psx - 1 && !visited[right]) {
-			stack.push(right);
-		}
-		if (y > 0 && !visited[up]) {
-			stack.push(up);
-		}
-		if (y < psy - 1 && !visited[down]) {
-			stack.push(down);
+			uint64_t loc = static_cast<uint64_t>(cur.x) + sx * (
+				static_cast<uint64_t>(cur.y) + sy * static_cast<uint64_t>(cur.z)
+			);
+			uint64_t ploc = x + psx * y;
+			
+			out[ploc] = labels[loc];
 		}
 	}
 

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -847,8 +847,6 @@ std::tuple<LABEL*, int64_t, Bbox2d> cross_section_projection(
 		return std::tuple(out, psx, bbx);
 	}
 
-	std::vector<bool> visited(psx * psy);
-
 	bbx.x_min = psx - 1;
 	bbx.x_max = 0;
 	bbx.y_min = psy - 1;

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -799,11 +799,11 @@ Bbox2d compute_slice_plane(
 		return ceil(std::max(std::max(dyx, dyy), dyz));
 	};
 
-	float dx_min = minfn(basis1);
-	float dx_max = maxfn(basis1);
+	float dx_min = minfn(basis1) - 1;
+	float dx_max = maxfn(basis1) + 1;
 
-	float dy_min = minfn(basis2);
-	float dy_max = maxfn(basis2);
+	float dy_min = minfn(basis2) - 1;
+	float dy_max = maxfn(basis2) + 1;
 
 	return Bbox2d(dx_min, dx_max, dy_min, dy_max);
 }
@@ -849,13 +849,10 @@ std::tuple<LABEL*, int64_t, Bbox2d> cross_section_projection(
 
 	std::vector<bool> visited(psx * psy);
 
-	bbx.x_min = sx;
+	bbx.x_min = psx - 1;
 	bbx.x_max = 0;
-	bbx.y_min = sy;
+	bbx.y_min = psy - 1;
 	bbx.y_max = 0;
-
-	// plane_bbx.print();
-	// pos.print("pos");
 
 	for (int64_t y = 0; y < psy; y++) {
 		for (int64_t x = 0; x < psx; x++) {
@@ -864,8 +861,7 @@ std::tuple<LABEL*, int64_t, Bbox2d> cross_section_projection(
 			float dy = static_cast<float>(y) + static_cast<float>(plane_bbx.y_min);
 
 			Vec3 cur = pos + basis1 * dx + basis2 * dy;	
-			// printf("%.1f %.1f\n", dx, dy);
-			// cur.print("cur");
+
 			if (cur.x < 0 || cur.y < 0 || cur.z < 0) {
 				continue;
 			}
@@ -873,22 +869,21 @@ std::tuple<LABEL*, int64_t, Bbox2d> cross_section_projection(
 				continue;
 			}
 
+			uint64_t loc = static_cast<uint64_t>(cur.x) + sx * (
+				static_cast<uint64_t>(cur.y) + sy * static_cast<uint64_t>(cur.z)
+			);
+
 			bbx.x_min = std::min(bbx.x_min, x);
 			bbx.x_max = std::max(bbx.x_max, x);
 			bbx.y_min = std::min(bbx.y_min, y);
 			bbx.y_max = std::max(bbx.y_max, y);
 
-			uint64_t loc = static_cast<uint64_t>(cur.x) + sx * (
-				static_cast<uint64_t>(cur.y) + sy * static_cast<uint64_t>(cur.z)
-			);
-			// printf("%d, %d\n", x,y);
 			uint64_t ploc = x + psx * y;
-			
 			out[ploc] = labels[loc];
 		}
 	}
 
-	// bbx.print();
+	bbx.print();
 
 	return std::tuple(out, psx, bbx);
 }

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -809,15 +809,14 @@ Bbox2d compute_slice_plane(
 }
 
 template <typename LABEL>
-std::tuple<LABEL*, Bbox2d> cross_section_projection(
+std::tuple<LABEL*, uint64_t, Bbox2d> cross_section_projection(
 	const LABEL* labels,
 	const uint64_t sx, const uint64_t sy, const uint64_t sz,
 	
 	const float px, const float py, const float pz,
 	const float nx, const float ny, const float nz,
 	const float wx, const float wy, const float wz,
-	const bool positive_basis,
-	LABEL* out = NULL
+	const bool positive_basis
 ) {
 	const Vec3 anisotropy(wx, wy, wz);
 	const Vec3 pos(px, py, pz);
@@ -836,18 +835,16 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 	const uint64_t psx = plane_bbx.sx();
 	const uint64_t psy = plane_bbx.sy();
 
-	if (out == NULL) {
-		out = new LABEL[psx * psy]();
-	}
+	LABEL* out = new LABEL[psx * psy]();
 
 	if (px < 0 || px >= sx) {
-		return std::tuple(out, bbx);
+		return std::tuple(out, psx, bbx);
 	}
 	else if (py < 0 || py >= sy) {
-		return std::tuple(out, bbx);
+		return std::tuple(out, psx, bbx);
 	}
 	else if (pz < 0 || pz >= sz) {
-		return std::tuple(out, bbx);
+		return std::tuple(out, psx, bbx);
 	}
 
 	std::vector<bool> visited(psx * psy);
@@ -884,6 +881,7 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 			uint64_t loc = static_cast<uint64_t>(cur.x) + sx * (
 				static_cast<uint64_t>(cur.y) + sy * static_cast<uint64_t>(cur.z)
 			);
+			// printf("%d, %d\n", x,y);
 			uint64_t ploc = x + psx * y;
 			
 			out[ploc] = labels[loc];
@@ -892,7 +890,7 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 
 	// bbx.print();
 
-	return std::tuple(out, bbx);
+	return std::tuple(out, psx, bbx);
 }
 
 };

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -776,9 +776,9 @@ Bbox2d compute_slice_plane(
 ) {
 
 	auto minfn = [&](const Vec3& basis) {
-		float dxx = -pos.x / basis.x;
-		float dxy = -pos.y / basis.y;
-		float dxz = -pos.z / basis.z;
+		float dxx = -pos.x * sqrt(3) / basis.x;
+		float dxy = -pos.y * sqrt(3) / basis.y;
+		float dxz = -pos.z * sqrt(3) / basis.z;
 
 		dxx = std::isinf(dxx) ? INFINITY : dxx;
 		dxy = std::isinf(dxy) ? INFINITY : dxy;
@@ -788,9 +788,9 @@ Bbox2d compute_slice_plane(
 	};
 
 	auto maxfn = [&](const Vec3& basis) {
-		float dyx = (sx-pos.x) / basis.x;
-		float dyy = (sy-pos.y) / basis.y;
-		float dyz = (sz-pos.z) / basis.z;
+		float dyx = (sqrt(3) * sx-pos.x) / basis.x;
+		float dyy = (sqrt(3) * sy-pos.y) / basis.y;
+		float dyz = (sqrt(3) * sz-pos.z) / basis.z;
 
 		dyx = std::isinf(dyx)? -INFINITY : dyx;
 		dyy = std::isinf(dyy)? -INFINITY : dyy;
@@ -882,8 +882,6 @@ std::tuple<LABEL*, int64_t, Bbox2d> cross_section_projection(
 			out[ploc] = labels[loc];
 		}
 	}
-
-	bbx.print();
 
 	return std::tuple(out, psx, bbx);
 }


### PR DESCRIPTION
The slowest part of the slice operation is the plane allocation, which is very large because it is was simple to not assume which direction will be drawn on. 

(512 * sqrt(3) * 2 * anisotropy(10))^2 * 8 bytes = 2.5 GB

However, if we calculate the plane area we actually need, only a fraction of that allocation is needed.

With a smaller plane, there is no need to use a stack. We can just use regular loops. 

The main issue here is whether I did the calculation right. So far so good...