### PR TITLE
perf: more performance tuning on area_of_poly

### DIFF
--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -47,6 +47,11 @@ public:
 	Vec3 operator-(const float scalar) const {
 		return Vec3(x - scalar, y - scalar, z - scalar);
 	}
+	void operator-=(const Vec3& other) {
+		x -= other.x;
+		y -= other.y;
+		z -= other.z;
+	}
 	Vec3 operator*(const float scalar) const {
 		return Vec3(x * scalar, y * scalar, z * scalar);
 	}

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -315,14 +315,13 @@ float area_of_poly(
 	}
 	centroid /= static_cast<float>(N_pts);
 
-	std::vector<Vec3> spokes;
-	spokes.reserve(N_pts);
+	static thread_local std::vector<Vec3> spokes(6);
 	
-	for (Vec3 pt : pts) {
-		spokes.push_back(pt - centroid);
+	for (size_t i = 0; i < N_pts; i++) {
+		spokes[i] = (pts[i] - centroid);
 	}
 
-	Vec3 prime_spoke = (pts[0] - centroid);
+	Vec3 prime_spoke = spokes[0];
 	prime_spoke /= prime_spoke.norm();
 
 	Vec3 basis = prime_spoke.cross(normal);


### PR DESCRIPTION
- Refactor to eliminate code ugliness and repetition of loops in network sorts
- Use loop unrolling to reduce overheads. 
- Eliminate unnecessary recalculation of prime_spike.
- Statically allocate spokes to avoid allocation overheads.

Experiments on an M3 suggest a speed increase of ~5%.