### PR TITLE
fix: off-by-half errors in mapping position to voxel location

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -277,9 +277,15 @@ def test_empty():
 @pytest.mark.parametrize("normal", [[1,0,0], [0,1,0], [0,0,1], [1,1,1], [-1,-1,1], [.3,-.2,.7]])
 def test_moving_window(off, normal):
     labels = np.zeros([100,100,100], dtype=bool, order="F")
-    
     labels[:off, :off, :off] = True
     initial_area = xs3d.cross_sectional_area(labels, [off//2, off//2, off//2], normal)
+    initial_area_slow = xs3d.cross_sectional_area(labels, [off//2, off//2, off//2], normal, slow_method=True)
+
+    xs = xs3d.cross_section(labels, [off//2, off//2, off//2], normal, slow_method=False)
+    xs2 = xs3d.cross_section(labels, [off//2, off//2, off//2], normal, slow_method=True)
+
+    assert np.isclose(initial_area, initial_area_slow)
+    assert np.isclose(xs.sum(), xs2.sum())
 
     for i in range(30):
         labels[:] = False
@@ -287,7 +293,6 @@ def test_moving_window(off, normal):
 
         area = xs3d.cross_sectional_area(labels, [i+off//2, i+off//2, i+off//2], normal)
         assert np.isclose(area, initial_area)
-
 
 
 def test_cross_section():

--- a/automated_test.py
+++ b/automated_test.py
@@ -403,7 +403,7 @@ def test_off_axis_all_counted():
     fast_result = xs3d.cross_sectional_area(arr, point, normal)
     slow_result = xs3d.cross_sectional_area(arr, point, normal, slow_method=True)
 
-    assert fast_result == slow_result
+    assert np.isclose(fast_result, slow_result)
 
 
 

--- a/src/fastxs3d.cpp
+++ b/src/fastxs3d.cpp
@@ -14,7 +14,8 @@ auto section(
 	const py::array_t<uint8_t> &binimg,
 	const py::array_t<float> &point,
 	const py::array_t<float> &normal,
-	const py::array_t<float> &anisotropy
+	const py::array_t<float> &anisotropy,
+	const bool slow_method
 ) {
 	const uint64_t sx = binimg.shape()[0];
 	const uint64_t sy = binimg.ndim() < 2
@@ -30,14 +31,28 @@ auto section(
     float* data = static_cast<float*>(arr.request().ptr);
     std::fill(data, data + voxels, 0.0f);
 
-	std::tuple<float*, uint8_t> tup = xs3d::cross_section(
-		binimg.data(),
-		sx, sy, sz,
-		point.at(0), point.at(1), point.at(2),
-		normal.at(0), normal.at(1), normal.at(2),
-		anisotropy.at(0), anisotropy.at(1), anisotropy.at(2),
-		data
-	);
+	std::tuple<float*, uint8_t> tup;
+
+	if (slow_method) {
+		tup = xs3d::cross_section_slow(
+			binimg.data(),
+			sx, sy, sz,
+			point.at(0), point.at(1), point.at(2),
+			normal.at(0), normal.at(1), normal.at(2),
+			anisotropy.at(0), anisotropy.at(1), anisotropy.at(2),
+			data
+		);
+	}
+	else {
+		 tup = xs3d::cross_section(
+			binimg.data(),
+			sx, sy, sz,
+			point.at(0), point.at(1), point.at(2),
+			normal.at(0), normal.at(1), normal.at(2),
+			anisotropy.at(0), anisotropy.at(1), anisotropy.at(2),
+			data
+		);
+	}
 
 	return std::make_tuple(arr, std::get<1>(tup));
 }

--- a/src/vec.hpp
+++ b/src/vec.hpp
@@ -91,6 +91,9 @@ public:
 	Vec3 abs() const {
 		return Vec3(std::abs(x), std::abs(y), std::abs(z));
 	}
+	Vec3 round() const {
+		return Vec3(std::round(x), std::round(y), std::round(z));
+	}
 	int argmax() const {
 		if (x >= y) {
 			return (x >= z) ? 0 : 2;

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -156,6 +156,9 @@ float calc_area_at_point(
 	const std::vector<float>& inv_projections,
 	float* plane_visualization
 ) {
+
+	const uint64_t voxels = sx * sy * sz;
+
 	float subtotal = 0.0;
 
 	float xs = (cur.x - 1) >= 0 ? -1 : 0;
@@ -187,22 +190,30 @@ float calc_area_at_point(
 				Vec3 delta(x,y,z);
 				delta += cur;
 
-				uint64_t loc = static_cast<uint64_t>(std::round(delta.x)) + sx * (
-					static_cast<uint64_t>(std::round(delta.y)) + sy * static_cast<uint64_t>(std::round(delta.z))
+				// boundaries between voxels are located at 0.5
+				delta.x = std::round(delta.x);
+				delta.y = std::round(delta.y);
+				delta.z = std::round(delta.z);
+
+				uint64_t loc = static_cast<uint64_t>(delta.x) + sx * (
+					static_cast<uint64_t>(delta.y) + sy * static_cast<uint64_t>(delta.z)
 				);
 
-				if (!binimg[loc]) {
+				if (loc < 0 || loc >= voxels) {
+					continue;
+				}
+				else if (!binimg[loc]) {
 					continue;
 				}
 
 				if (ccl[loc] == 0) {
 					ccl[loc] = 1;
 					
-					check_intersections(
+					float area = check_intersections(
 						pts, 
-						static_cast<uint64_t>(std::round(delta.x)), 
-						static_cast<uint64_t>(std::round(delta.y)), 
-						static_cast<uint64_t>(std::round(delta.z)),
+						static_cast<uint64_t>(delta.x), 
+						static_cast<uint64_t>(delta.y), 
+						static_cast<uint64_t>(delta.z),
 						pos, normal, 
 						projections, inv_projections
 					);

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -770,6 +770,10 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 		stack.push(ploc);
 	}
 
+	const float sxf = static_cast<float>(sx) - 0.5;
+	const float syf = static_cast<float>(sy) - 0.5;
+	const float szf = static_cast<float>(sz) - 0.5;
+
 	while (!stack.empty()) {
 		ploc = stack.top();
 		stack.pop();
@@ -789,15 +793,17 @@ std::tuple<LABEL*, Bbox2d> cross_section_projection(
 		Vec3 delta = basis1 * dx + basis2 * dy;
 		Vec3 cur = pos + delta;
 
-		if (cur.x < 0 || cur.y < 0 || cur.z < 0) {
+		if (cur.x < -0.5 || cur.y < -0.5 || cur.z < -0.5) {
 			continue;
 		}
-		else if (cur.x >= sx || cur.y >= sy || cur.z >= sz) {
+		else if (cur.x >= sxf || cur.y >= syf || cur.z >= szf) {
 			continue;
 		}
 		else if (delta.norm2() >= crop_distance_sq) {
 			continue;
 		}
+
+		cur = cur.round();
 
 		bbx.x_min = std::min(bbx.x_min, static_cast<int64_t>(x));
 		bbx.x_max = std::max(bbx.x_max, static_cast<int64_t>(x));

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -209,7 +209,7 @@ float calc_area_at_point(
 				if (ccl[loc] == 0) {
 					ccl[loc] = 1;
 					
-					float area = check_intersections(
+					check_intersections(
 						pts, 
 						static_cast<uint64_t>(delta.x), 
 						static_cast<uint64_t>(delta.y), 

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -187,8 +187,8 @@ float calc_area_at_point(
 				Vec3 delta(x,y,z);
 				delta += cur;
 
-				uint64_t loc = static_cast<uint64_t>(delta.x) + sx * (
-					static_cast<uint64_t>(delta.y) + sy * static_cast<uint64_t>(delta.z)
+				uint64_t loc = static_cast<uint64_t>(std::round(delta.x)) + sx * (
+					static_cast<uint64_t>(std::round(delta.y)) + sy * static_cast<uint64_t>(std::round(delta.z))
 				);
 
 				if (!binimg[loc]) {
@@ -200,9 +200,9 @@ float calc_area_at_point(
 					
 					check_intersections(
 						pts, 
-						static_cast<uint64_t>(delta.x), 
-						static_cast<uint64_t>(delta.y), 
-						static_cast<uint64_t>(delta.z),
+						static_cast<uint64_t>(std::round(delta.x)), 
+						static_cast<uint64_t>(std::round(delta.y)), 
+						static_cast<uint64_t>(std::round(delta.z)),
 						pos, normal, 
 						projections, inv_projections
 					);

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -218,7 +218,7 @@ float calc_area_at_point(
 						projections, inv_projections
 					);
 
-					float area = xs3d::area::points_to_area(pts, anisotropy, normal);
+					const float area = xs3d::area::points_to_area(pts, anisotropy, normal);
 					subtotal += area;
 
 					if (plane_visualization != NULL && area > 0.0) {
@@ -559,7 +559,6 @@ std::tuple<float*, uint8_t> cross_section(
 	Vec3 normal(nx, ny, nz);
 	normal /= normal.norm();
 
-
 	cross_sectional_area_helper(
 		binimg, 
 		sx, sy, sz, 
@@ -601,8 +600,6 @@ std::tuple<float*, uint8_t> cross_section_slow(
 
 	std::vector<Vec3> pts;
 	pts.reserve(6);
-
-	float area = 0;
 
 	const std::vector<float> projections = {
 		ihat.dot(normal),

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -473,7 +473,7 @@ float cross_sectional_area_slow(
 	std::vector<Vec3> pts;
 	pts.reserve(6);
 
-	float area = 0;
+	double area = 0;
 
 	const std::vector<float> projections = {
 		ihat.dot(normal),

--- a/xs3d/__init__.py
+++ b/xs3d/__init__.py
@@ -87,6 +87,7 @@ def cross_section(
   normal:VECTOR_T,
   anisotropy:Optional[VECTOR_T] = None,
   return_contact:bool = False,
+  slow_method:bool = False,
 ) -> Union[npt.NDArray[np.float32], tuple[npt.NDArray[np.float32], int]]:
   """
   Compute which voxels are intercepted by a section plane
@@ -140,7 +141,7 @@ def cross_section(
   if binimg.ndim != 3:
     raise ValueError("dimensions not supported")
   
-  section, contact = fastxs3d.section(binimg, pos, normal, anisotropy)
+  section, contact = fastxs3d.section(binimg, pos, normal, anisotropy, slow_method)
 
   if return_contact:
     return (section, contact)


### PR DESCRIPTION
Code was inappropriately treating `Vec3 cur` like an integer. Each voxel is -0.5 to +0.5 otherwise there are aliasing errors in computing the current position.