### PR TITLE
perf: persistent buffer with colored pens

### DIFF
--- a/src/aux.hpp
+++ b/src/aux.hpp
@@ -190,14 +190,13 @@ std::tuple<float*, uint8_t> cross_section_slow(
  * connected component, so pre-filtering must be performed to 
  * ensure a match.
  */
-float cross_sectional_area_slow(
+std::tuple<float, uint8_t> cross_sectional_area_slow(
 	const uint8_t* binimg,
 	const uint64_t sx, const uint64_t sy, const uint64_t sz,
 	
 	const float px, const float py, const float pz,
 	const float nx, const float ny, const float nz,
-	const float wx, const float wy, const float wz,
-	uint8_t &contact = _dummy_contact
+	const float wx, const float wy, const float wz
 ) {
 
 	const Vec3 pos(px, py, pz);
@@ -208,7 +207,7 @@ float cross_sectional_area_slow(
 		|| rpos.y < 0 || rpos.y >= sy 
 		|| rpos.z < 0 || rpos.z >= sz
 	) {
-		return 0.0;
+		return std::make_tuple(0.0, 0);
 	}
 
 	const Vec3 anisotropy(wx, wy, wz);
@@ -233,7 +232,7 @@ float cross_sectional_area_slow(
 			: 1.0 / projections[i];
 	}
 
-	contact = 0;
+	uint8_t contact = 0;
 
 	for (uint64_t z = 0; z < sz; z++) {
 		for (uint64_t y = 0; y < sy; y++) {
@@ -263,7 +262,7 @@ float cross_sectional_area_slow(
 		}
 	}
 
-	return area;
+	return std::make_tuple(area, contact);
 }
 
 };

--- a/src/fastxs3d.cpp
+++ b/src/fastxs3d.cpp
@@ -221,19 +221,6 @@ PYBIND11_MODULE(fastxs3d, m) {
 	m.def("section", &section, "Return a floating point image that shows the voxels contributing area to a cross section.");
 	m.def("area", &calculate_area, "Find the cross sectional area for a given binary image, point, and normal vector.");
 	
-	m.def("set_shape", [](py::array_t<uint8_t> &binimg) {
-			py::buffer_info buf = binimg.request();
-			if (buf.ndim > 3) {
-				throw std::runtime_error("Number of dimensions must be <= 3");
-			}
-			const uint64_t sx = buf.shape[0];
-			const uint64_t sy = (buf.ndim >= 2) ? buf.shape[1] : 1;
-			const uint64_t sz = (buf.ndim >= 3) ? buf.shape[2] : 1;
-			xs3d::set_shape(static_cast<uint8_t*>(buf.ptr), sx, sy, sz);
-		}, 
-		py::arg("binimg"), 
-		"Accelerate the area function across many evaluation points by saving some attributes of the input shape upfront. Call clear_shape when you are done."
-	);
-
+	m.def("set_shape", &xs3d::set_shape, "Accelerate the area function across many evaluation points by saving some attributes of the input shape upfront. Call clear_shape when you are done.");
 	m.def("clear_shape", &xs3d::clear_shape, "Delete the data that was persisted by set_shape.");
 }

--- a/src/fastxs3d.cpp
+++ b/src/fastxs3d.cpp
@@ -94,31 +94,24 @@ auto calculate_area(
 		? 1 
 		: binimg.shape()[2];
 
-	uint8_t contact = false;
-	float area = 0;
-
 	if (slow_method) {
-		area = xs3d::cross_sectional_area_slow(
+		return xs3d::cross_sectional_area_slow(
 			binimg.data(),
 			sx, sy, sz,
 			point.at(0), point.at(1), point.at(2),
 			normal.at(0), normal.at(1), normal.at(2),
-			anisotropy.at(0), anisotropy.at(1), anisotropy.at(2),
-			contact
+			anisotropy.at(0), anisotropy.at(1), anisotropy.at(2)
 		);
 	}
 	else {
-		area = xs3d::cross_sectional_area(
+		return xs3d::cross_sectional_area(
 			binimg.data(),
 			sx, sy, sz,
 			point.at(0), point.at(1), point.at(2),
 			normal.at(0), normal.at(1), normal.at(2),
-			anisotropy.at(0), anisotropy.at(1), anisotropy.at(2),
-			contact
+			anisotropy.at(0), anisotropy.at(1), anisotropy.at(2)
 		);
 	}
-
-	return std::tuple(area, contact);
 }
 
 auto projection(	

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -68,7 +68,7 @@ struct PersistentShapeManager {
 
 	void maybe_grow(const uint64_t _sx, const uint64_t _sy, const uint64_t _sz) {
 		if (sx * sy * sz < _sx * _sy * _sz) {
-			init(_sx, _sy, sz);
+			init(_sx, _sy, _sz);
 		}
 	}
 

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -32,15 +32,19 @@ uint8_t compute_cube(
 	const uint64_t sxy = sx * sy;
 	const uint64_t loc = x + sx * (y + sy * z);
 
+    const uint64_t x_valid = (x < sx - 1);
+    const uint64_t y_valid = (y < sy - 1);
+    const uint64_t z_valid = (z < sz - 1);
+
 	return static_cast<uint8_t>(
 		(binimg[loc] > 0)
-		| (((x < sx - 1) && (binimg[loc+1] > 0)) << 1)
-		| (((y < sy - 1) && (binimg[loc+sx] > 0)) << 2)
-		| (((x < sx - 1 && y < sy - 1) && (binimg[loc+sx+1] > 0)) << 3)
-		| (((z < sz - 1) && (binimg[loc+sxy] > 0)) << 4)
-		| (((x < sx - 1 && z < sz - 1) && (binimg[loc+sxy+1] > 0)) << 5)
-		| (((y < sy - 1 && z < sz - 1) && (binimg[loc+sxy+sx] > 0)) << 6)
-		| (((x < sx - 1 && y < sy - 1 && z < sz - 1) && (binimg[loc+sxy+sx+1] > 0)) << 7)
+		| ((x_valid && (binimg[loc+1] > 0)) << 1)
+		| ((y_valid && (binimg[loc+sx] > 0)) << 2)
+		| (((x_valid && y_valid) && (binimg[loc+sx+1] > 0)) << 3)
+		| ((z_valid && (binimg[loc+sxy] > 0)) << 4)
+		| (((x_valid && z_valid) && (binimg[loc+sxy+1] > 0)) << 5)
+		| (((y_valid && z_valid) && (binimg[loc+sxy+sx] > 0)) << 6)
+		| (((x_valid && y_valid && z_valid) && (binimg[loc+sxy+sx+1] > 0)) << 7)
 	);
 }
 

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -829,7 +829,7 @@ std::tuple<float, uint8_t> cross_sectional_area_helper_2x2x2(
 	const uint64_t grid_size = std::max(((sx+1)>>1) * ((sy+1)>>1) * ((sz+1)>>1), static_cast<uint64_t>(1));
 	std::vector<bool> ccl(grid_size);
 
-	uint8_t contact;
+	uint8_t contact = 0;
 
 	// rational approximation of sqrt(3) is 97/56
 	// more reliable behavior across compilers/architectures
@@ -982,7 +982,7 @@ std::tuple<float, uint8_t> cross_sectional_area_helper_2x2x2_persistent_data(
 ) {
 	persistent_data.next_color();
 
-	uint8_t contact;
+	uint8_t contact = 0;
 
 	// rational approximation of sqrt(3) is 97/56
 	// more reliable behavior across compilers/architectures

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -20,6 +20,10 @@ namespace {
 
 static uint8_t _dummy_contact = false;
 
+uint64_t _h(uint64_t a) { 
+	return ((a+1) >> 1); 
+};
+
 uint8_t compute_cube(
 	const uint8_t* binimg,
 	const uint64_t sx, const uint64_t sy, const uint64_t sz,
@@ -44,27 +48,29 @@ struct PersistentShapeManager {
 	std::vector<uint8_t> visited;
 	std::vector<uint8_t> cubes;
 	uint64_t sx, sy, sz;
-	T color;
+	uint8_t color;
 
-	PersistentShapeManager(const uint8_t* binimg, const uint64_t _sx, const uint64_t _sy, const uint64_t _sz) {
-		init(binimg, _sx, _sy, _sz);
-		color = 1;
+	PersistentShapeManager() {
+		sx = 0; sy = 0; sz = 0;
+		color = 0;
 	}
 
-	void init(const uint64_t _sx, const uint64_t _sy, const uint64_t _sz) {
+	void init(const uint8_t* binimg, const uint64_t _sx, const uint64_t _sy, const uint64_t _sz) {
 		sx = _sx;
 		sy = _sy;
 		sz = _sz;
 		precompute_cubes(binimg);
-		visited.resize(this->voxels());
+		visited.resize(this->eighth_voxels());
 	}
 
-	void precompute_cubes(uint8_t* binimg) {
-		cubes.resize(
-			((sx+1) >> 1)
-			* ((sy+1) >> 1)
-			* ((sz+1) >> 1)
-		);
+	uint8_t get_cube(const uint64_t x, const uint64_t y, const uint64_t z) {
+		return cubes[
+			_h(x) + _h(sx) * (_h(y) + _h(sy) * _h(z))
+		];
+	}
+
+	void precompute_cubes(const uint8_t* binimg) {
+		cubes.resize(this->eighth_voxels());
 
 		uint64_t i = 0;
 		for (uint64_t z = 0; z < sz; z += 2) {
@@ -80,21 +86,13 @@ struct PersistentShapeManager {
 		sx = 0;
 		sy = 0;
 		sz = 0;
-		color = 1;
-		visited = std::vector<T>[0]();
-		cubes = std::vector<uint8_t>[0]();
+		color = 0;
+		visited = std::vector<uint8_t>();
+		cubes = std::vector<uint8_t>();
 	}
 
-	void next(const uint64_t _sx, const uint64_t _sy, const uint64_t _sz) {
-		sx = _sx;
-		sy = _sy;
-		sz = _sz;
-		next_color();
-		visited.resize(this->voxels());
-	}
-
-	uint64_t voxels() {
-		return sx * sy * sz;
+	uint64_t eighth_voxels() {
+		return _h(sx) * _h(sy) * _h(sz);
 	}
 
 	uint8_t next_color() {
@@ -740,6 +738,87 @@ float robust_calc_area_at_point_2x2x2(
 	return subtotal;
 }
 
+float robust_calc_area_at_point_2x2x2_persistent_data(
+	const uint8_t* binimg,
+	const uint64_t sx, const uint64_t sy, const uint64_t sz,
+	const Vec3& cur, const Vec3& pos, 
+	const Vec3& normal, const Vec3& anisotropy,
+	std::vector<Vec3>& pts, 
+	const std::vector<float>& projections, 
+	const std::vector<float>& inv_projections
+) {
+
+	uint64_t x = static_cast<uint64_t>(cur.x) & ~static_cast<uint64_t>(1);
+	uint64_t y = static_cast<uint64_t>(cur.y) & ~static_cast<uint64_t>(1);
+	uint64_t z = static_cast<uint64_t>(cur.z) & ~static_cast<uint64_t>(1);
+
+	float subtotal = 0.0;
+
+	float xs = (cur.x - 2) >= 0 ? -2 : 0;
+	float ys = (cur.y - 2) >= 0 ? -2 : 0;
+	float zs = (cur.z - 2) >= 0 ? -2 : 0;
+
+	float xe = (cur.x + 2) < sx ? 2 : 0;
+	float ye = (cur.y + 2) < sy ? 2 : 0;
+	float ze = (cur.z + 2) < sz ? 2 : 0;
+	
+	// only need to check around the current voxel if
+	// there's a possibility that there is a gap due
+	// to basis vector motion. If the normal is axis
+	// aligned to x, y, or z, there will be no gap.
+	if (normal.is_axis_aligned()) {
+		xs = 0;
+		ys = 0;
+		zs = 0;
+
+		xe = 0;
+		ye = 0;
+		ze = 0;		
+	}
+
+	const uint8_t center = persistent_data.get_cube(x,y,z);
+	std::vector<uint8_t>& visited = persistent_data.visited;
+	uint8_t color = persistent_data.color;
+
+	for (int64_t zi = zs; zi <= ze; zi += 2) {
+		for (int64_t yi = ys; yi <= ye; yi += 2) {
+			for (int64_t xi = xs; xi <= xe; xi += 2) {
+				
+				Vec3 delta(xi,yi,zi);
+				delta += cur;
+
+				const uint64_t loc = static_cast<uint64_t>(delta.x) + sx * (
+					static_cast<uint64_t>(delta.y) + sy * static_cast<uint64_t>(delta.z)
+				);
+
+				const uint64_t visited_loc =  (static_cast<uint64_t>(delta.x) >> 1) + ((sx+1) >> 1) * (
+					(static_cast<uint64_t>(delta.y) >> 1) + ((sy+1) >> 1) * (static_cast<uint64_t>(delta.z) >> 1)
+				);
+
+				if (!binimg[loc] || visited[visited_loc] == color) {
+					continue;
+				}
+				
+				visited[visited_loc] = color;
+					
+				uint8_t candidate = persistent_data.get_cube(x+xi, y+yi, z+zi);
+
+				if (is_26_connected(center, candidate, xi, yi, zi)) {
+					subtotal += calc_area_at_point_2x2x2(
+						candidate,
+						sx, sy, sz,
+						delta, pos, normal, anisotropy,
+						pts, 
+						projections, inv_projections
+					);
+				}
+			}
+		}
+	}
+
+	return subtotal;
+}
+
 std::tuple<float, uint8_t> cross_sectional_area_helper_2x2x2(
 	const uint8_t* binimg,
 	const uint64_t sx, const uint64_t sy, const uint64_t sz,
@@ -893,6 +972,160 @@ std::tuple<float, uint8_t> cross_sectional_area_helper_2x2x2(
 
 	return std::make_tuple(total, contact);
 }
+
+std::tuple<float, uint8_t> cross_sectional_area_helper_2x2x2_persistent_data(
+	const uint8_t* binimg,
+	const uint64_t sx, const uint64_t sy, const uint64_t sz,
+	const Vec3& pos, // plane position
+	const Vec3& normal, // plane normal vector
+	const Vec3& anisotropy
+) {
+	persistent_data.next_color();
+
+	uint8_t contact;
+
+	// rational approximation of sqrt(3) is 97/56
+	// more reliable behavior across compilers/architectures
+	uint64_t plane_size = 2 * 97 * std::max(std::max(sx,sy), sz) / 56 + 1;
+
+	// maximum possible size of plane
+	uint64_t psx = plane_size;
+	uint64_t psy = psx;
+
+	std::vector<bool> visited(psx * psy);
+
+	Vec3 basis1 = normal.cross(ihat);
+	if (basis1.is_null()) {
+		basis1 = normal.cross(jhat);
+	}
+	basis1 /= basis1.norm();
+
+	Vec3 basis2 = normal.cross(basis1);
+	basis2 /= basis2.norm();
+
+	uint64_t plane_pos_x = plane_size / 2;
+	uint64_t plane_pos_y = plane_size / 2;
+
+	uint64_t ploc = plane_pos_x + psx * plane_pos_y;
+
+	std::stack<uint64_t> stack;
+	stack.push(ploc);
+
+	float total = 0.0;
+
+	std::vector<Vec3> pts;
+	pts.reserve(6);
+
+	const std::vector<float> projections = {
+		ihat.dot(normal),
+		jhat.dot(normal),
+		khat.dot(normal)
+	};
+
+	std::vector<float> inv_projections(3);
+	for (int i = 0; i < 3; i++) {
+		inv_projections[i] = (projections[i] == 0)
+			? 0
+			: 1.0 / projections[i];
+	}
+
+	const float sxf = static_cast<float>(sx) - 0.5;
+	const float syf = static_cast<float>(sy) - 0.5;
+	const float szf = static_cast<float>(sz) - 0.5;
+
+	while (!stack.empty()) {
+		ploc = stack.top();
+		stack.pop();
+
+		if (visited[ploc]) {
+			continue;
+		}
+
+		visited[ploc] = true;
+
+		uint64_t y = ploc / psx;
+		uint64_t x = ploc - y * psx;
+
+		float dx = static_cast<float>(x) - static_cast<float>(plane_pos_x);
+		float dy = static_cast<float>(y) - static_cast<float>(plane_pos_y);
+
+		Vec3 cur = pos + basis1 * dx + basis2 * dy;
+
+		if (cur.x < -0.5 || cur.y < -0.5 || cur.z < -0.5) {
+			continue;
+		}
+		else if (cur.x >= sxf || cur.y >= syf || cur.z >= szf) {
+			continue;
+		}
+
+		cur = cur.round();
+
+		uint64_t loc = (
+			static_cast<uint64_t>(cur.x)
+			+ sx * (
+				static_cast<uint64_t>(cur.y)
+				+ sy * static_cast<uint64_t>(cur.z)
+			)
+		);
+
+		if (!binimg[loc]) {
+			continue;
+		}
+
+		contact |= (cur.x < 1); // -x
+		contact |= (cur.x >= sx - 1.5) << 1; // +x
+		contact |= (cur.y < 1) << 2; // -y
+		contact |= (cur.y >= sy - 1.5) << 3; // +y
+		contact |= (cur.z < 1) << 4; // -z
+		contact |= (cur.z >= sz - 1.5) << 5; // +z
+
+		uint64_t up = ploc - psx; 
+		uint64_t down = ploc + psx;
+		uint64_t left = ploc - 1;
+		uint64_t right = ploc + 1;
+
+		uint64_t upleft = ploc - psx - 1; 
+		uint64_t downleft = ploc + psx - 1;
+		uint64_t upright = ploc - psx + 1;
+		uint64_t downright = ploc + psx + 1;
+
+		if (x > 0 && !visited[left]) {
+			stack.push(left);
+		}
+		if (x < psx - 1 && !visited[right]) {
+			stack.push(right);
+		}
+		if (y > 0 && !visited[up]) {
+			stack.push(up);
+		}
+		if (y < psy - 1 && !visited[down]) {
+			stack.push(down);
+		}
+
+		if (x > 0 && y > 0 && !visited[upleft]) {
+			stack.push(upleft);
+		}
+		if (x < psx - 1 && y > 0 && !visited[upright]) {
+			stack.push(upright);
+		}
+		if (x > 0 && y < psy - 1 && !visited[downleft]) {
+			stack.push(downleft);
+		}
+		if (x < psx - 1 && y < psy - 1 && !visited[downright]) {
+			stack.push(downright);
+		}
+
+		total += robust_calc_area_at_point_2x2x2_persistent_data(
+			binimg,
+			sx, sy, sz,
+			cur, pos, normal, anisotropy,
+			pts, projections, inv_projections
+		);
+	}
+
+	return std::make_tuple(total, contact);
+}
+
 
 float cross_sectional_area_helper(
 	const uint8_t* binimg,
@@ -1089,7 +1322,8 @@ std::tuple<float, uint8_t> cross_sectional_area(
 	
 	const float px, const float py, const float pz,
 	const float nx, const float ny, const float nz,
-	const float wx, const float wy, const float wz
+	const float wx, const float wy, const float wz,
+	const bool use_persistent_data = false
 ) {
 
 	if (px < 0 || px >= sx) {
@@ -1128,11 +1362,20 @@ std::tuple<float, uint8_t> cross_sectional_area(
 	Vec3 normal(nx, ny, nz);
 	normal /= normal.norm();
 
-	return cross_sectional_area_helper_2x2x2(
-		binimg, 
-		sx, sy, sz, 
-		pos, normal, anisotropy
-	);
+	if (use_persistent_data) {
+		return cross_sectional_area_helper_2x2x2_persistent_data(
+			binimg, 
+			sx, sy, sz, 
+			pos, normal, anisotropy
+		);
+	}
+	else {
+		return cross_sectional_area_helper_2x2x2(
+			binimg, 
+			sx, sy, sz, 
+			pos, normal, anisotropy
+		);
+	}
 }
 
 std::tuple<float*, uint8_t> cross_section(

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -780,8 +780,8 @@ float robust_calc_area_at_point_2x2x2_persistent_data(
 					static_cast<uint64_t>(delta.y) + sy * static_cast<uint64_t>(delta.z)
 				);
 
-				const uint64_t visited_loc =  (static_cast<uint64_t>(delta.x) >> 1) + ((sx+1) >> 1) * (
-					(static_cast<uint64_t>(delta.y) >> 1) + ((sy+1) >> 1) * (static_cast<uint64_t>(delta.z) >> 1)
+				const uint64_t visited_loc =  (static_cast<uint64_t>(delta.x) >> 1) + _h(sx) * (
+					(static_cast<uint64_t>(delta.y) >> 1) + _h(sy) * (static_cast<uint64_t>(delta.z) >> 1)
 				);
 
 				if (!binimg[loc] || visited[visited_loc] == color) {

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -20,6 +20,7 @@ namespace {
 
 static uint8_t _dummy_contact = false;
 
+// half rounded up
 uint64_t _h(uint64_t a) { 
 	return ((a+1) >> 1); 
 };

--- a/src/xs3d.hpp
+++ b/src/xs3d.hpp
@@ -699,8 +699,8 @@ float robust_calc_area_at_point_2x2x2(
 					static_cast<uint64_t>(delta.y) + sy * static_cast<uint64_t>(delta.z)
 				);
 
-				const uint64_t ccl_loc =  (static_cast<uint64_t>(delta.x) >> 1) + ((sx+1) >> 1) * (
-					(static_cast<uint64_t>(delta.y) >> 1) + ((sy+1) >> 1) * (static_cast<uint64_t>(delta.z) >> 1)
+				const uint64_t ccl_loc =  (static_cast<uint64_t>(delta.x) >> 1) + _h(sx) * (
+					(static_cast<uint64_t>(delta.y) >> 1) + _h(sy) * (static_cast<uint64_t>(delta.z) >> 1)
 				);
 
 				if (!binimg[loc] || ccl[ccl_loc]) {

--- a/xs3d/__init__.py
+++ b/xs3d/__init__.py
@@ -15,6 +15,7 @@ def cross_sectional_area(
   anisotropy:Optional[VECTOR_T] = None,
   return_contact:bool = False,
   slow_method:bool = False,
+  use_persistent_data:bool = False,
 ) -> Union[float, tuple[float, int]]:
   """
   Find the cross sectional area for a given binary image, 
@@ -75,7 +76,7 @@ def cross_sectional_area(
     area, contact = fastxs3d.area(
       binimg.view(np.uint8),
       pos, normal, anisotropy, 
-      slow_method
+      slow_method, use_persistent_data,
     )
   else:
     raise ValueError("dimensions not supported")
@@ -225,6 +226,11 @@ def slice(
   )
 
 
+def set_shape(binimg):
+  fastxs3d.set_shape(binimg)
+
+def clear_shape():
+  fastxs3d.clear_shape()
 
 
 

--- a/xs3d/__init__.py
+++ b/xs3d/__init__.py
@@ -48,6 +48,12 @@ def cross_sectional_area(
     all locations are visited. Does not restrict analysis
     to a single connected component.
 
+  use_persistent_data: Use a pre-allocated buffer for
+    internally tacking visited positions. You allocate the
+    buffer with xs3d.set_shape and clear it with xs3d.clear_shape.
+    This can save about 20% of the time when repeatedly
+    analyzing a shape.
+
   Returns: physical area covered by the section plane
   """
   if anisotropy is None:
@@ -225,11 +231,19 @@ def slice(
     crop
   )
 
+def set_shape(image:npt.NDArray[np.integer]):
+  """
+  Allocate a buffer appropriately sized to this image for internal use.
+  This can accelerate the area calculation if there are repeated queries
+  against the same shape.
 
-def set_shape(binimg):
-  fastxs3d.set_shape(binimg)
+  It is very important that the persisted shape match the current input
+  or memory issues can result.
+  """
+  fastxs3d.set_shape(image.shape[0], image.shape[1], image.shape[2])
 
 def clear_shape():
+  """Free the persisted memory from set_shape."""
   fastxs3d.clear_shape()
 
 


### PR DESCRIPTION
Allocating and zeroing the visit buffer can be a significant cost. Even though most of the algorithm doesn't touch most of the volume, zeroing requires touching every voxel, meaning each query on a given shape is O(V * K) where V is the number of voxels and K is the number of queries. Since we were using a std::vector<bool> that reduced the cost 8x, and when we implemented 2x2x2, that reduced the cost 64x, but we can do better.

Instead of zeroing the buffer each time, let's use std::vector<uint8_t>, zero it to start, and then draw in a different color for each visit. Then we only need to zero it once every 255 times.

The memory grows 8x vs std::vector<bool>, but the amortized cost of zeroing is now 31.9 times less (255 / 8).

This behavior will be opt in as you need to intentionally allocate and deallocate the buffer. If you forget, the buffer will automatically grow as needed, but you'll have a memory leak.

I also tried experimenting with pre-computing all the "cubes", but since most of the volume is usually untouched, and most planes along a skeleton don't intersect much, there is a negative impact to doing so.




